### PR TITLE
Improve searching style and functionality

### DIFF
--- a/src/app/components.tsx
+++ b/src/app/components.tsx
@@ -23,9 +23,13 @@ export const TableHeader: React.FC<ComponentProps> = ({ children, className }) =
   );
 };
 
-export const TableHeaderCell: React.FC<ComponentProps> = ({ children, className }) => {
+interface TableHeaderCellProps extends ComponentProps {
+  width?: string;
+}
+
+export const TableHeaderCell: React.FC<TableHeaderCellProps> = ({ children, className, width }) => {
   return (
-    <th className={`p-3 border border-gray-300 bg-gray-200 text-gray-700 font-semibold ${className}`}>
+    <th style={{ width }} className={`p-3 border border-gray-300 bg-gray-200 text-gray-700 font-semibold ${className}`}>
       {children}
     </th>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,14 +19,16 @@ export default function Home() {
 
   const filteredAdvocates = useMemo(() => {
     if (!searchTerm) return advocates;
+    const loweredTerm = searchTerm.toLowerCase();
     return advocates.filter((advocate) => {
       return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience === parseInt(searchTerm)
+        advocate.firstName.toLowerCase().includes(loweredTerm) ||
+        advocate.lastName.toLowerCase().includes(loweredTerm) ||
+        advocate.city.toLowerCase().includes(loweredTerm) ||
+        advocate.degree.toLowerCase().includes(loweredTerm) ||
+        advocate.specialties.some((specialty) => specialty.toLowerCase().includes(loweredTerm)) ||
+        advocate.yearsOfExperience === parseInt(loweredTerm) ||
+        advocate.phoneNumber.toString().includes(loweredTerm)
       );
     });
   }, [advocates, searchTerm])
@@ -36,26 +38,32 @@ export default function Home() {
       <h1>Solace Advocates</h1>
       <br />
       <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for:
-        </p>
-        <input style={{ border: "1px solid black" }} value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
-        <button onClick={() => setSearchTerm('')}>Reset Search</button>
+      <div className="flex flex-col sm:flex-row items-center gap-2 pb-4">
+        <input
+          id="search"
+          type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          placeholder="Type to search..."
+          className="w-full sm:w-64 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <button
+          onClick={() => setSearchTerm('')}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+        >
+          Reset
+        </button>
       </div>
-      <br />
-      <br />
       <Table>
         <TableHeader>
           <tr>
-            <TableHeaderCell>First Name</TableHeaderCell>
-            <TableHeaderCell>Last Name</TableHeaderCell>
-            <TableHeaderCell>City</TableHeaderCell>
-            <TableHeaderCell>Degree</TableHeaderCell>
-            <TableHeaderCell>Specialties</TableHeaderCell>
-            <TableHeaderCell>Years of Experience</TableHeaderCell>
-            <TableHeaderCell>Phone Number</TableHeaderCell>
+            <TableHeaderCell width="10%">First Name</TableHeaderCell>
+            <TableHeaderCell width="10%">Last Name</TableHeaderCell>
+            <TableHeaderCell width="10%">City</TableHeaderCell>
+            <TableHeaderCell width="5%">Degree</TableHeaderCell>
+            <TableHeaderCell width="45%">Specialties</TableHeaderCell>
+            <TableHeaderCell width="10%">Years of Experience</TableHeaderCell>
+            <TableHeaderCell width="10%">Phone Number</TableHeaderCell>
           </tr>
         </TableHeader>
         <tbody>


### PR DESCRIPTION
Styled the search box and reset button

Improved the logic of the filter function. 
- Compare all the strings lower case so the user can type "john" instead of "John".
- Search the specialties separately so we can do partial matching instead of matching the whole specialty.
- Added phone number searching using partial matching by converting the number to a string.

In the case of having 100k+ advocates to search through the approach for searching would need to be completely different. Client side filtering would be much too expensive/slow. I would do the searching directly through a db query using trigram indices on all the columns where we're doing partial matching. Additionally I would use a package like tanstack useQuery to properly handle the requests from the frontend on updating the search term. With 100k+ advocates this table would also need pagination so that would need to be added to the api endpoint and db queries as well.

Added some fixed width to table columns so the table doesn't shift and resize as the user searches.

![Screenshot 2025-02-23 151725](https://github.com/user-attachments/assets/5f10ef15-cfc4-470d-b276-a7062d019e58)
